### PR TITLE
fix: remove compressed from download url

### DIFF
--- a/frontend/src/views/Admin/Orders/index.jsx
+++ b/frontend/src/views/Admin/Orders/index.jsx
@@ -210,6 +210,10 @@ const Orders = () => {
     }
   };
 
+  const removeCompressedFromImage = (image) => {
+    return image.replace("/compressed", "");
+  };
+
   useEffect(() => {
     getOrdersProducts();
   }, []);
@@ -397,7 +401,7 @@ const Orders = () => {
                                     className="download-icon"
                                     onClick={() => {
                                       DownloadFile(
-                                        get(jsonData, "0.image"),
+                                        removeCompressedFromImage(get(jsonData, "0.image")),
                                         `${selectedOrder.sku}-product-${item.id}`
                                       );
                                     }}

--- a/frontend/src/views/Admin/Orders/index.jsx
+++ b/frontend/src/views/Admin/Orders/index.jsx
@@ -211,7 +211,10 @@ const Orders = () => {
   };
 
   const removeCompressedFromImage = (image) => {
-    return image.replace("/compressed", "");
+    if(image.includes("/compressed")){
+      return image.replace("/compressed", "");
+    }
+    return image;
   };
 
   useEffect(() => {

--- a/frontend/src/views/Associats/Orders/index.jsx
+++ b/frontend/src/views/Associats/Orders/index.jsx
@@ -133,6 +133,10 @@ const Orders = () => {
     getOrdersProducts();
   }, []);
 
+  const removeCompressedFromImage = (image) => {
+    return image.replace("/compressed", "");
+  };
+
   return (
     <OrdersContainer>
       <Helmet>
@@ -257,7 +261,7 @@ const Orders = () => {
                                     className="download-icon"
                                     onClick={() => {
                                       DownloadFile(
-                                        get(jsonData, "0.image"),
+                                        removeCompressedFromImage(get(jsonData, "0.image")),
                                         `${selectedOrder.sku}-product-${item.id}`
                                       );
                                     }}

--- a/frontend/src/views/Associats/Orders/index.jsx
+++ b/frontend/src/views/Associats/Orders/index.jsx
@@ -134,7 +134,10 @@ const Orders = () => {
   }, []);
 
   const removeCompressedFromImage = (image) => {
-    return image.replace("/compressed", "");
+    if(image.includes("/compressed")){
+      return image.replace("/compressed", "");
+    }
+    return image;
   };
 
   return (


### PR DESCRIPTION
The call for downloading the image was using the JSON data from the response to get the Image URL, that by default has the compressed in it.
So I have created a function to remove the "compressed" from the image URL, so that it now calls the backend API that gets the original image and not the compressed one, and this was done only on the Orders modal for the Admin and Associate