### PR TITLE
feat: add status check to get and update

### DIFF
--- a/backend/src/modules/associate-products/associate-products.service.ts
+++ b/backend/src/modules/associate-products/associate-products.service.ts
@@ -61,6 +61,12 @@ export class AssociateProductsService extends AbstractService {
         },
       };
     }
+
+    if (filterDto.status) {
+      const queryStatusFlag = filterDto.status === 'true' ? 1 : 0;
+      where = { ...where, product: { status: queryStatusFlag } };
+    }
+
     if (filterDto.search_string) {
       where = { ...where, name: Like(`%${filterDto.search_string}%`) };
     }

--- a/backend/src/modules/associate-products/dto/get-associate-product-filter.input.ts
+++ b/backend/src/modules/associate-products/dto/get-associate-product-filter.input.ts
@@ -30,4 +30,7 @@ export class GetAssociateProductFilterInputDto {
 
   @ApiPropertyOptional()
   page?: number;
+
+  @ApiPropertyOptional()
+  status: 'true' | 'false' | null;
 }

--- a/backend/src/modules/product-variants/entities/product-variants.entity.ts
+++ b/backend/src/modules/product-variants/entities/product-variants.entity.ts
@@ -31,6 +31,10 @@ export class ProductVariants {
   @Column('int', { name: 'color_id', nullable: true })
   color_id: number | null;
 
+  @ValidateIf((val) => val.variant_status !== null)
+  @Column('boolean', { name: 'variant_status', nullable: true, default: () => 'true' })
+  variant_status: boolean | null;
+
   @ValidateIf((val) => val.image_id !== null)
   @MaxLength(36)
   @Column('varchar', { name: 'image_id', nullable: true })

--- a/backend/src/modules/products/dto/create-products.input.ts
+++ b/backend/src/modules/products/dto/create-products.input.ts
@@ -17,6 +17,9 @@ export class productVariants {
   @ApiProperty()
   image_id: string | null;
 
+  @ApiProperty()
+  variant_status: boolean | null;
+
   @ApiProperty({ type: [productSubVariants] })
   @Type(() => productSubVariants)
   @ValidateNested({ each: true })

--- a/backend/src/modules/products/dto/filter-input.dto.ts
+++ b/backend/src/modules/products/dto/filter-input.dto.ts
@@ -9,4 +9,7 @@ export class filterInputDto {
 
   @ApiPropertyOptional()
   search_string: string | null;
+
+  @ApiPropertyOptional()
+  status: 'true' | 'false' | null;
 }

--- a/backend/src/modules/products/products.service.ts
+++ b/backend/src/modules/products/products.service.ts
@@ -12,6 +12,7 @@ import { ProductSubVariants } from '../product-sub-variants/entities/product-sub
 import { filterInputDto } from './dto/filter-input.dto';
 import { masterFilterInputDto } from './dto/master-filter.dto';
 import { productVariantsRepository } from '../product-variants/repository/product-variants.repository';
+import { log } from 'node:console';
 
 @Injectable()
 export class ProductsService extends AbstractService {
@@ -96,6 +97,7 @@ export class ProductsService extends AbstractService {
               product_id: id,
               color_id: product_variant.color_id,
               image_id: product_variant.image_id,
+              variant_status: product_variant.variant_status,
             },
           );
           for (const variant of product_variant.sub_variants) {
@@ -158,6 +160,12 @@ export class ProductsService extends AbstractService {
     }
     if (query.search_string) {
       where = { ...where, name: Like(`%${query.search_string}%`) };
+    }
+
+    
+    if (query.status) {
+      const queryStatusFlag = query.status === 'true' ? 1 : 0
+      where = { ...where, status: queryStatusFlag };
     }
     const findProduct = await this.find({
       where,


### PR DESCRIPTION
Status flag je vec postojao za Product, proveravao sam i primetio sam da se ne koristi nigde, pa sam to iskoristio umesto da pravim novi product_status.

A za product variants tu sam dodao flag variant_status.
On se salje kada se updejtuje ili kreira product, po defaultu je true.
Takodje dodao sam search QueryParam za product i assocate product, ?status=true ili status=false -> ovo vraca sve produkte koji su aktivni ili neaktivni
A sto se tice product_variantsa to ce se proveravati samo da li je status aktivan ili ne, i ta boja ce biti prikaza ili ne